### PR TITLE
Remove Namespace Rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@krauters/eslint-config",
-	"version": "1.4.0",
+	"version": "1.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@krauters/eslint-config",
-			"version": "1.4.0",
+			"version": "1.4.2",
 			"license": "ISC",
 			"dependencies": {
 				"@stylistic/eslint-plugin-ts": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@krauters/eslint-config",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "TypeScript linting configuration.",
 	"author": "Colten Krauter <coltenkrauter>",
 	"main": "dist/eslint.config.js",

--- a/rules.js
+++ b/rules.js
@@ -180,7 +180,6 @@ const tsEslint = {
 	'import/no-cycle': error,
 	'import/no-duplicates': error,
 	'import/no-empty-named-blocks': error,
-	'import/no-namespace': error,
 	'import/no-relative-packages': error,
 	'import/no-self-import': error,
 	'import/no-unresolved': error,


### PR DESCRIPTION
## Description

Fighting with some errors in consuming projects.

```
Oops! Something went wrong! :(

ESLint: 9.15.0

TypeError: Cannot read properties of undefined (reading 'node')
Occurred while linting /Users/coltenkrauter/Repositories/pike-backend/src/graphql/services/auth-service.ts:8
Rule: "import/no-namespace"
    at /Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint-plugin-import/lib/rules/no-namespace.js:114:102
    at Array.find (<anonymous>)
    at ImportNamespaceSpecifier (/Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint-plugin-import/lib/rules/no-namespace.js:114:52)
    at ruleErrorHandler (/Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint/lib/linter/linter.js:1098:48)
    at /Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/Users/coltenkrauter/Repositories/pike-backend/node_modules/eslint/lib/linter/node-event-generator.js:337:14)
```

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Chore
- [ ] Configuration
- [ ] Documentation
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security
- [ ] GitFlow

## Testing

- [ ] Executed locally
- [ ] Unit tests
- [ ] Integration tests
- [ ] Load tests
- [x] PR Status checks
- [ ] Workflow execution (against non-default branch)
- [ ] Other (explain)
- [ ] Not worth it (explain)
- [ ] Not applicable

## Checklist
[Not required to be completed, just check off what you've done.]

- [ ] Commits are reasonably **sized** and the **commit message** describes the changes well.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have added **unit tests** for changes to business logic.
- [ ] I have emitted **metrics** so our team can monitor the health of this system related to these changes.
- [ ] I have added **logs** to ensure **debugging** is straight-forward when issues arise.
- [ ] I have **considered failure** modes (e.g. major dependency becomes unavailable, bad data passed in).
- [ ] I have added a comment to this PR to discuss any **concerns/risks** of these changes. This might include effects on performance, new dependencies, changes in behavior, or difficult things to test.
- [ ] I have considered whether some of these changes should go into a shared package to increase code reusability.

<!-- This template lives in the "krauters/.github" repository in the location ".github/PULL_REQUEST_TEMPLATE.md" -->
